### PR TITLE
feat: Refactor Rust prediction module and integrate new data types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ output/*
 smartscore/lib/*
 .vscode/*
 smartscore/Rust/make_predictions/target/*
+smartscore/Rust/weight_optimizer/target/*
 .env
 node_modules
 .venv

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-.PHONY: local-setup
 local-setup:
 	@echo Creating virtual environment
 	@poetry env activate
@@ -8,44 +7,36 @@ install:
 	@echo Installing all dev dependencies
 	@poetry install --with dev
 
-.PHONY: check-ci
 check-ci:
 	@echo "Checking CI configuration"
 	@$(MAKE) compile
 	@$(MAKE) lint
 	@$(MAKE) test
 
-.PHONY: lint
 lint:
 	@echo "Linting code"
 	@poetry run pre-commit run -a
 
-.PHONY: test
 test:
 	@echo "Running tests"
 	@poetry run pytest -v
 
-.PHONY: compile
 compile:
 	@$(MAKE) compile_rust
 	@$(MAKE) compile_c
 
-.PHONY: compile_c
 compile_c:
 	@echo "Compiling C code"
 	@gcc -Wall -std=c99 -shared -o smartscore/compiled_code.so -fPIC smartscore/C/main.c
 
-.PHONE: compile_rust
 compile_rust:
 	@echo "Compiling Rust code"
 	@poetry run maturin develop -r --manifest-path smartscore/Rust/make_predictions/Cargo.toml
 
-.PHONY: get_odds
 get_odds:
 	@echo "Getting odds"
 	@ENV=prod poetry run python smartscore/scripts/get_odds.py
 
-.PHONY: watch_live
 watch_live:
 	@echo "Running live"
 	@poetry run python smartscore/scripts/live_updates.py

--- a/smartscore/Rust/make_predictions/Cargo.lock
+++ b/smartscore/Rust/make_predictions/Cargo.lock
@@ -15,6 +15,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,8 +107,10 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 name = "make_predictions_rust"
 version = "0.1.0"
 dependencies = [
+ "crossbeam",
  "itertools",
  "pyo3",
+ "rayon",
 ]
 
 [[package]]
@@ -155,6 +213,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/smartscore/Rust/make_predictions/Cargo.toml
+++ b/smartscore/Rust/make_predictions/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module"] }
 itertools = "0.10"
+rayon = "1.7"
+crossbeam = "0.8"
 
 [lib]
 name = "make_predictions_rust"

--- a/smartscore/Rust/make_predictions/src/data_types.rs
+++ b/smartscore/Rust/make_predictions/src/data_types.rs
@@ -1,0 +1,205 @@
+use pyo3::Bound;
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+#[pyclass]
+#[derive(Clone)]
+pub struct PlayerInfo {
+    #[pyo3(get, set)]
+    pub gpg: f32,
+    #[pyo3(get, set)]
+    pub hgpg: f32,
+    #[pyo3(get, set)]
+    pub five_gpg: f32,
+    #[pyo3(get, set)]
+    pub tgpg: f32,
+    #[pyo3(get, set)]
+    pub otga: f32,
+    #[pyo3(get, set)]
+    pub hppg: f32,
+    #[pyo3(get, set)]
+    pub otshga: f32,
+    #[pyo3(get, set)]
+    pub is_home: f32,
+    #[pyo3(get, set)]
+    pub hppg_otshga: f32,
+    #[pyo3(get, set)]
+    pub scored: f32,
+    #[pyo3(get, set)]
+    pub tims: i32,
+    #[pyo3(get, set)]
+    pub date: String,
+}
+
+#[pymethods]
+impl PlayerInfo {
+    #[new]
+    pub fn new(gpg: f32, hgpg: f32, five_gpg: f32, tgpg: f32, otga: f32, hppg: f32,
+               otshga: f32, is_home: f32, hppg_otshga: f32, scored: f32, tims: i32, date: String) -> Self {
+        Self {
+            gpg,
+            hgpg,
+            five_gpg,
+            tgpg,
+            otga,
+            hppg,
+            otshga,
+            is_home,
+            hppg_otshga,
+            scored,
+            tims,
+            date,
+        }
+    }
+
+    #[classmethod]
+    fn default(_cls: &Bound<'_, PyType>) -> Self {
+        Self {
+            gpg: 0.0, hgpg: 0.0, five_gpg: 0.0, tgpg: 0.0,
+            otga: 0.0, hppg: 0.0, otshga: 0.0, is_home: 0.0,
+            hppg_otshga: 0.0, scored: 0.0, tims: 0, date: "".to_string(),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct MinMax {
+    #[pyo3(get, set)]
+    pub min_gpg: f32,
+    #[pyo3(get, set)]
+    pub max_gpg: f32,
+    #[pyo3(get, set)]
+    pub min_hgpg: f32,
+    #[pyo3(get, set)]
+    pub max_hgpg: f32,
+    #[pyo3(get, set)]
+    pub min_five_gpg: f32,
+    #[pyo3(get, set)]
+    pub max_five_gpg: f32,
+    #[pyo3(get, set)]
+    pub min_tgpg: f32,
+    #[pyo3(get, set)]
+    pub max_tgpg: f32,
+    #[pyo3(get, set)]
+    pub min_otga: f32,
+    #[pyo3(get, set)]
+    pub max_otga: f32,
+    #[pyo3(get, set)]
+    pub min_hppg: f32,
+    #[pyo3(get, set)]
+    pub max_hppg: f32,
+    #[pyo3(get, set)]
+    pub min_otshga: f32,
+    #[pyo3(get, set)]
+    pub max_otshga: f32,
+}
+
+#[pymethods]
+impl MinMax {
+    #[new]
+    pub fn new(
+        min_gpg: f32, max_gpg: f32,
+        min_hgpg: f32, max_hgpg: f32,
+        min_five_gpg: f32, max_five_gpg: f32,
+        min_tgpg: f32, max_tgpg: f32,
+        min_otga: f32, max_otga: f32,
+        min_hppg: f32, max_hppg: f32,
+        min_otshga: f32, max_otshga: f32,
+    ) -> Self {
+        Self {
+            min_gpg, max_gpg,
+            min_hgpg, max_hgpg,
+            min_five_gpg, max_five_gpg,
+            min_tgpg, max_tgpg,
+            min_otga, max_otga,
+            min_hppg, max_hppg,
+            min_otshga, max_otshga,
+        }
+    }
+
+    #[classmethod]
+    fn default(_cls: &Bound<'_, PyType>) -> Self {
+        Self {
+            min_gpg: f32::MAX, max_gpg: f32::MIN,
+            min_hgpg: f32::MAX, max_hgpg: f32::MIN,
+            min_five_gpg: f32::MAX, max_five_gpg: f32::MIN,
+            min_tgpg: f32::MAX, max_tgpg: f32::MIN,
+            min_otga: f32::MAX, max_otga: f32::MIN,
+            min_hppg: f32::MAX, max_hppg: f32::MIN,
+            min_otshga: f32::MAX, max_otshga: f32::MIN,
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Weights {
+    #[pyo3(get, set)]
+    pub gpg: f32,
+    #[pyo3(get, set)]
+    pub hgpg: f32,
+    #[pyo3(get, set)]
+    pub five_gpg: f32,
+    #[pyo3(get, set)]
+    pub tgpg: f32,
+    #[pyo3(get, set)]
+    pub otga: f32,
+    #[pyo3(get, set)]
+    pub is_home: f32,
+    #[pyo3(get, set)]
+    pub hppg_otshga: f32,
+}
+
+// Implement Display for Weights
+use std::fmt;
+impl fmt::Display for Weights {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Weights(gpg: {:.6}, five_gpg: {:.6}, hgpg: {:.6}, tgpg: {:.6}, otga: {:.6}, hppg_otshga: {:.6}, is_home: {:.6})",
+            self.gpg, self.five_gpg, self.hgpg, self.tgpg, self.otga, self.hppg_otshga, self.is_home
+        )
+    }
+}
+
+#[pymethods]
+impl Weights {
+    #[new]
+    pub fn new(gpg: f32, hgpg: f32, five_gpg: f32, tgpg: f32, otga: f32,
+               is_home: f32, hppg_otshga: f32) -> Self {
+        Self {
+            gpg,
+            hgpg,
+            five_gpg,
+            tgpg,
+            otga,
+            is_home,
+            hppg_otshga,
+        }
+    }
+
+    #[classmethod]
+    fn default(_cls: &Bound<'_, PyType>) -> Self {
+        Self {
+            gpg: 1.0,
+            hgpg: 1.0,
+            five_gpg: 1.0,
+            tgpg: 1.0,
+            otga: 1.0,
+            is_home: 1.0,
+            hppg_otshga: 1.0,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Weights(gpg: {:.6}, five_gpg: {:.6}, hgpg: {:.6}, tgpg: {:.6}, otga: {:.6}, hppg_otshga: {:.6}, is_home: {:.6})",
+            self.gpg, self.five_gpg, self.hgpg, self.tgpg, self.otga, self.hppg_otshga, self.is_home
+        )
+    }
+
+    fn __str__(&self) -> String {
+        self.__repr__()
+    }
+}

--- a/smartscore/Rust/make_predictions/src/data_types.rs
+++ b/smartscore/Rust/make_predictions/src/data_types.rs
@@ -24,18 +24,34 @@ pub struct PlayerInfo {
     #[pyo3(get, set)]
     pub hppg_otshga: f32,
     #[pyo3(get, set)]
-    pub scored: f32,
+    pub scored: Option<f32>,
     #[pyo3(get, set)]
-    pub tims: i32,
+    pub tims: Option<i32>,
     #[pyo3(get, set)]
-    pub date: String,
+    pub date: Option<String>,
 }
 
 #[pymethods]
 impl PlayerInfo {
     #[new]
-    pub fn new(gpg: f32, hgpg: f32, five_gpg: f32, tgpg: f32, otga: f32, hppg: f32,
-               otshga: f32, is_home: f32, hppg_otshga: f32, scored: f32, tims: i32, date: String) -> Self {
+    #[pyo3(signature = (
+        gpg, hgpg, five_gpg, tgpg, otga, hppg, otshga, is_home, hppg_otshga,
+        scored=None, tims=None, date=None
+    ))]
+    pub fn new(
+        gpg: f32,
+        hgpg: f32,
+        five_gpg: f32,
+        tgpg: f32,
+        otga: f32,
+        hppg: f32,
+        otshga: f32,
+        is_home: f32,
+        hppg_otshga: f32,
+        scored: Option<f32>,
+        tims: Option<i32>,
+        date: Option<String>
+    ) -> Self {
         Self {
             gpg,
             hgpg,
@@ -57,7 +73,7 @@ impl PlayerInfo {
         Self {
             gpg: 0.0, hgpg: 0.0, five_gpg: 0.0, tgpg: 0.0,
             otga: 0.0, hppg: 0.0, otshga: 0.0, is_home: 0.0,
-            hppg_otshga: 0.0, scored: 0.0, tims: 0, date: "".to_string(),
+            hppg_otshga: 0.0, scored: None, tims: None, date: None,
         }
     }
 }

--- a/smartscore/Rust/make_predictions/src/lib.rs
+++ b/smartscore/Rust/make_predictions/src/lib.rs
@@ -1,220 +1,18 @@
-use pyo3::Bound;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use pyo3::types::PyType;
 
+mod data_types;
+mod predictions;
+mod weight_testing;
+mod weight_generation;
 
-#[pyclass]
-#[derive(Clone)]
-pub struct PlayerInfo {
-    #[pyo3(get, set)]
-    pub gpg: f32,
-    #[pyo3(get, set)]
-    pub hgpg: f32,
-    #[pyo3(get, set)]
-    pub five_gpg: f32,
-    #[pyo3(get, set)]
-    pub tgpg: f32,
-    #[pyo3(get, set)]
-    pub otga: f32,
-    #[pyo3(get, set)]
-    pub hppg: f32,
-    #[pyo3(get, set)]
-    pub otshga: f32,
-    #[pyo3(get, set)]
-    pub is_home: f32,
-    #[pyo3(get, set)]
-    pub hppg_otshga: f32,
-}
+// Re-export the data types for Python
+pub use data_types::{PlayerInfo, MinMax, Weights};
 
-#[pymethods]
-impl PlayerInfo {
-    #[new]
-    pub fn new(gpg: f32, hgpg: f32, five_gpg: f32, tgpg: f32, otga: f32, hppg: f32, 
-               otshga: f32, is_home: f32, hppg_otshga: f32) -> Self {
-        Self {
-            gpg,
-            hgpg,
-            five_gpg,
-            tgpg,
-            otga,
-            hppg,
-            otshga,
-            is_home,
-            hppg_otshga,
-        }
-    }
-
-    #[classmethod]
-    fn default(_cls: &Bound<'_, PyType>) -> Self {
-        Self {
-            gpg: 0.0, hgpg: 0.0, five_gpg: 0.0, tgpg: 0.0,
-            otga: 0.0, hppg: 0.0, otshga: 0.0, is_home: 0.0,
-            hppg_otshga: 0.0,
-        }
-    }
-}
-
-#[pyclass]
-#[derive(Clone)]
-pub struct MinMax {
-    #[pyo3(get, set)]
-    pub min_gpg: f32,
-    #[pyo3(get, set)]
-    pub max_gpg: f32,
-    #[pyo3(get, set)]
-    pub min_hgpg: f32,
-    #[pyo3(get, set)]
-    pub max_hgpg: f32,
-    #[pyo3(get, set)]
-    pub min_five_gpg: f32,
-    #[pyo3(get, set)]
-    pub max_five_gpg: f32,
-    #[pyo3(get, set)]
-    pub min_tgpg: f32,
-    #[pyo3(get, set)]
-    pub max_tgpg: f32,
-    #[pyo3(get, set)]
-    pub min_otga: f32,
-    #[pyo3(get, set)]
-    pub max_otga: f32,
-    #[pyo3(get, set)]
-    pub min_hppg: f32,
-    #[pyo3(get, set)]
-    pub max_hppg: f32,
-    #[pyo3(get, set)]
-    pub min_otshga: f32,
-    #[pyo3(get, set)]
-    pub max_otshga: f32,
-}
-
-#[pymethods]
-impl MinMax {
-    #[new]
-    pub fn new(
-        min_gpg: f32, max_gpg: f32,
-        min_hgpg: f32, max_hgpg: f32,
-        min_five_gpg: f32, max_five_gpg: f32,
-        min_tgpg: f32, max_tgpg: f32,
-        min_otga: f32, max_otga: f32,
-        min_hppg: f32, max_hppg: f32,
-        min_otshga: f32, max_otshga: f32,
-    ) -> Self {
-        Self {
-            min_gpg, max_gpg,
-            min_hgpg, max_hgpg,
-            min_five_gpg, max_five_gpg,
-            min_tgpg, max_tgpg,
-            min_otga, max_otga,
-            min_hppg, max_hppg,
-            min_otshga, max_otshga,
-        }
-    }
-    
-    #[classmethod]
-    fn default(_cls: &Bound<'_, PyType>) -> Self {
-        Self {
-            min_gpg: f32::MAX, max_gpg: f32::MIN,
-            min_hgpg: f32::MAX, max_hgpg: f32::MIN,
-            min_five_gpg: f32::MAX, max_five_gpg: f32::MIN,
-            min_tgpg: f32::MAX, max_tgpg: f32::MIN,
-            min_otga: f32::MAX, max_otga: f32::MIN,
-            min_hppg: f32::MAX, max_hppg: f32::MIN,
-            min_otshga: f32::MAX, max_otshga: f32::MIN,
-        }
-    }
-}
-
-#[pyclass]
-#[derive(Clone, Copy)]
-pub struct Weights {
-    #[pyo3(get, set)]
-    pub gpg: f32,
-    #[pyo3(get, set)]
-    pub hgpg: f32,
-    #[pyo3(get, set)]
-    pub five_gpg: f32,
-    #[pyo3(get, set)]
-    pub tgpg: f32,
-    #[pyo3(get, set)]
-    pub otga: f32,
-    #[pyo3(get, set)]
-    pub is_home: f32,
-    #[pyo3(get, set)]
-    pub hppg_otshga: f32,
-}
-
-#[pymethods]
-impl Weights {
-    #[new]
-    pub fn new(gpg: f32, hgpg: f32, five_gpg: f32, tgpg: f32, otga: f32, 
-               is_home: f32, hppg_otshga: f32) -> Self {
-        Self {
-            gpg,
-            hgpg,
-            five_gpg,
-            tgpg,
-            otga,
-            is_home,
-            hppg_otshga,
-        }
-    }
-    
-    #[classmethod]
-    fn default(_cls: &Bound<'_, PyType>) -> Self {
-        Self {
-            gpg: 1.0,
-            hgpg: 1.0,
-            five_gpg: 1.0,
-            tgpg: 1.0,
-            otga: 1.0,
-            is_home: 1.0,
-            hppg_otshga: 1.0,
-        }
-    }
-}
-
-// Normalize stats
-fn normalize_stats(players: &mut [PlayerInfo], min_max: &MinMax) {
-    fn normalize(value: f32, min: f32, max: f32) -> f32 {
-        (value - min) / (max - min)
-    }
-
-    players.iter_mut().for_each(|player| {
-        player.gpg = normalize(player.gpg, min_max.min_gpg, min_max.max_gpg);
-        player.hgpg = normalize(player.hgpg, min_max.min_hgpg, min_max.max_hgpg);
-        player.five_gpg = normalize(player.five_gpg, min_max.min_five_gpg, min_max.max_five_gpg);
-        player.tgpg = normalize(player.tgpg, min_max.min_tgpg, min_max.max_tgpg);
-        player.otga = normalize(player.otga, min_max.min_otga, min_max.max_otga);
-        player.hppg = normalize(player.hppg, min_max.min_hppg, min_max.max_hppg);
-        player.otshga = normalize(player.otshga, min_max.min_otshga, min_max.max_otshga);
-        player.hppg_otshga = player.hppg * player.otshga;
-    });
-}
-
-// Calculate probabilities
-fn calculate_probabilities(players: &[PlayerInfo], probabilities: &mut [f32], weights: &Weights) {
-    probabilities.iter_mut().zip(players.iter()).for_each(|(p, player)| {
-        *p = player.gpg * weights.gpg
-            + player.five_gpg * weights.five_gpg
-            + player.hgpg * weights.hgpg
-            + player.tgpg * weights.tgpg
-            + player.otga * weights.otga
-            + player.hppg_otshga * weights.hppg_otshga
-            + player.is_home * weights.is_home;
-    });
-}
-
-// Predict daily
-#[pyfunction]
-fn predict(py: Python, mut players: Vec<PlayerInfo>, min_max: MinMax, weights: Weights) -> PyResult<PyObject> {
-    let mut probabilities = vec![0.0; players.len()];
-    normalize_stats(&mut players, &min_max);
-    calculate_probabilities(&players, &mut probabilities, &weights);
-
-    Ok(probabilities.into_pyobject(py)?.into_any().unbind())
-}
-
+// Re-export the functions for Python
+pub use predictions::predict;
+pub use weight_testing::test_weights;
+pub use weight_generation::generate_weight_permutations;
 
 // A Python module implemented in Rust.
 #[pymodule]
@@ -223,5 +21,7 @@ fn make_predictions_rust(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<(
     m.add_class::<MinMax>()?;
     m.add_class::<Weights>()?;
     m.add_function(wrap_pyfunction!(predict, m)?)?;
+    m.add_function(wrap_pyfunction!(test_weights, m)?)?;
+    m.add_function(wrap_pyfunction!(generate_weight_permutations, m)?)?;
     Ok(())
 }

--- a/smartscore/Rust/make_predictions/src/predictions.rs
+++ b/smartscore/Rust/make_predictions/src/predictions.rs
@@ -1,0 +1,43 @@
+use crate::data_types::{PlayerInfo, MinMax, Weights};
+use pyo3::prelude::*;
+
+// Normalize stats
+pub fn normalize_stats(players: &mut [PlayerInfo], min_max: &MinMax) {
+    fn normalize(value: f32, min: f32, max: f32) -> f32 {
+        (value - min) / (max - min)
+    }
+
+    players.iter_mut().for_each(|player| {
+        player.gpg = normalize(player.gpg, min_max.min_gpg, min_max.max_gpg);
+        player.hgpg = normalize(player.hgpg, min_max.min_hgpg, min_max.max_hgpg);
+        player.five_gpg = normalize(player.five_gpg, min_max.min_five_gpg, min_max.max_five_gpg);
+        player.tgpg = normalize(player.tgpg, min_max.min_tgpg, min_max.max_tgpg);
+        player.otga = normalize(player.otga, min_max.min_otga, min_max.max_otga);
+        player.hppg = normalize(player.hppg, min_max.min_hppg, min_max.max_hppg);
+        player.otshga = normalize(player.otshga, min_max.min_otshga, min_max.max_otshga);
+        player.hppg_otshga = player.hppg * player.otshga;
+    });
+}
+
+// Calculate probabilities
+pub fn calculate_probabilities(players: &[PlayerInfo], probabilities: &mut [f32], weights: &Weights) {
+    probabilities.iter_mut().zip(players.iter()).for_each(|(p, player)| {
+        *p = player.gpg * weights.gpg
+            + player.five_gpg * weights.five_gpg
+            + player.hgpg * weights.hgpg
+            + player.tgpg * weights.tgpg
+            + player.otga * weights.otga
+            + player.hppg_otshga * weights.hppg_otshga
+            + player.is_home * weights.is_home;
+    });
+}
+
+// Predict daily
+#[pyfunction]
+pub fn predict(py: Python, mut players: Vec<PlayerInfo>, min_max: MinMax, weights: Weights) -> PyResult<PyObject> {
+    let mut probabilities = vec![0.0; players.len()];
+    normalize_stats(&mut players, &min_max);
+    calculate_probabilities(&players, &mut probabilities, &weights);
+
+    Ok(probabilities.into_pyobject(py)?.into_any().unbind())
+}

--- a/smartscore/Rust/make_predictions/src/weight_generation.rs
+++ b/smartscore/Rust/make_predictions/src/weight_generation.rs
@@ -1,0 +1,46 @@
+use pyo3::prelude::*;
+use rayon::prelude::*;
+use crossbeam::channel::unbounded;
+
+/// Generate all possible weight combinations that sum to 1.0 using optimized mathematical approach
+#[pyfunction]
+pub fn generate_weight_permutations(_py: Python, step_size: f32) -> PyResult<Vec<crate::data_types::Weights>> {
+    let step = step_size / 100.0;
+    let target_steps = (1.0 / step) as i32;
+    let max_value = target_steps;
+
+    let (sender, receiver) = unbounded();
+
+    (0..=max_value).into_par_iter().for_each(|w0| {
+        for w1 in 0..=max_value {
+            for w2 in 0..=max_value {
+                for w3 in 0..=max_value {
+                    for w4 in 0..=max_value {
+                        for w5 in 0..=max_value {
+                            let total = w0 + w1 + w2 + w3 + w4 + w5;
+                            if total <= target_steps {
+                                let w6 = target_steps - total;
+
+                                let weights = crate::data_types::Weights {
+                                    gpg: w0 as f32 * step,
+                                    five_gpg: w1 as f32 * step,
+                                    hgpg: w2 as f32 * step,
+                                    tgpg: w3 as f32 * step,
+                                    otga: w4 as f32 * step,
+                                    hppg_otshga: w5 as f32 * step,
+                                    is_home: w6 as f32 * step,
+                                };
+                                sender.send(weights).unwrap();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    drop(sender);
+    let weight_combinations: Vec<_> = receiver.iter().collect();
+
+    Ok(weight_combinations)
+}

--- a/smartscore/Rust/make_predictions/src/weight_testing.rs
+++ b/smartscore/Rust/make_predictions/src/weight_testing.rs
@@ -7,12 +7,12 @@ pub fn test_weights(_py: Python, mut players: Vec<PlayerInfo>, min_max: crate::d
     let mut max_correct = -1;
     let mut best_weights = <Weights as Default>::default();
     let mut best_total = 0;
-    let total_combinations = weight_combinations.len();
-    let mut last_progress = 0;
+    let _total_combinations = weight_combinations.len();
+    let _last_progress = 0;
 
     normalize_stats(&mut players, &min_max);
 
-    for (i, weights) in weight_combinations.iter().enumerate() {
+    for (_i, weights) in weight_combinations.iter().enumerate() {
         let mut probabilities = vec![0.0; players.len()];
         calculate_probabilities(&players, &mut probabilities, &weights);
 
@@ -56,8 +56,10 @@ pub fn evaluate_correctness_with_total(players: &[PlayerInfo], probabilities: &[
         }
 
         // Only consider TIMS picks for predictions
-        if player.tims >= 1 && player.tims <= 3 {
-            current_date_players.push(i);
+        if let Some(tims) = player.tims {
+            if tims >= 1 && tims <= 3 {
+                current_date_players.push(i);
+            }
         }
     }
 
@@ -78,15 +80,17 @@ pub fn process_date_predictions(player_indices: &[usize], players: &[PlayerInfo]
     for &player_idx in player_indices.iter() {
         let player = &players[player_idx];
         let prob = probabilities[player_idx];
-        let group_idx = (player.tims - 1) as usize;
+        if let Some(tims) = player.tims {
+            let group_idx = (tims - 1) as usize;
 
-        if group_idx < 3 {
-            match &selected_players[group_idx] {
-                None => selected_players[group_idx] = Some((player_idx, prob)),
-                Some((_, current_prob)) if prob > *current_prob => {
-                    selected_players[group_idx] = Some((player_idx, prob));
+            if group_idx < 3 {
+                match &selected_players[group_idx] {
+                    None => selected_players[group_idx] = Some((player_idx, prob)),
+                    Some((_, current_prob)) if prob > *current_prob => {
+                        selected_players[group_idx] = Some((player_idx, prob));
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
     }
@@ -94,8 +98,10 @@ pub fn process_date_predictions(player_indices: &[usize], players: &[PlayerInfo]
     // Count correct predictions and total predictions made
     for selected in selected_players.iter() {
         if let Some((player_idx, _)) = selected {
-            if players[*player_idx].scored > 0.0 {
-                correct += 1;
+            if let Some(scored) = players[*player_idx].scored {
+                if scored > 0.0 {
+                    correct += 1;
+                }
             }
         }
     }

--- a/smartscore/Rust/make_predictions/src/weight_testing.rs
+++ b/smartscore/Rust/make_predictions/src/weight_testing.rs
@@ -1,0 +1,104 @@
+use crate::data_types::{PlayerInfo, Weights};
+use crate::predictions::{normalize_stats, calculate_probabilities};
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn test_weights(_py: Python, mut players: Vec<PlayerInfo>, min_max: crate::data_types::MinMax, weight_combinations: Vec<Weights>) -> PyResult<(Weights, i32, i32)> {
+    let mut max_correct = -1;
+    let mut best_weights = <Weights as Default>::default();
+    let mut best_total = 0;
+    let total_combinations = weight_combinations.len();
+    let mut last_progress = 0;
+
+    normalize_stats(&mut players, &min_max);
+
+    for (i, weights) in weight_combinations.iter().enumerate() {
+        let mut probabilities = vec![0.0; players.len()];
+        calculate_probabilities(&players, &mut probabilities, &weights);
+
+        let (correct, total) = evaluate_correctness_with_total(&players, &probabilities);
+
+        if correct >= max_correct {
+            max_correct = correct;
+            best_total = total;
+            best_weights = *weights;
+        }
+
+        // Print progress every 1%
+        // let current_progress = ((i + 1) as f64 / total_combinations as f64 * 100.0) as i32;
+        // if current_progress > last_progress {
+        //     println!("Progress: {}% ({}/{})", current_progress, i + 1, total_combinations);
+        //     last_progress = current_progress;
+        // }
+    }
+
+    Ok((best_weights, max_correct, best_total))
+}
+
+
+// Helper function to evaluate correctness and return both correct and total predictions
+pub fn evaluate_correctness_with_total(players: &[PlayerInfo], probabilities: &[f32]) -> (i32, i32) {
+    let mut correct = 0;
+    let mut total_predictions = 0;
+    let mut current_date_players = Vec::new();
+    let mut last_date = players[0].date.clone();
+
+    for (i, player) in players.iter().enumerate() {
+        if last_date != player.date {
+            // Process previous date - select 1 player from each TIMS group
+            let date_correct = process_date_predictions(&current_date_players, players, probabilities);
+            correct += date_correct;
+            total_predictions += 3;
+
+            // Reset for next date
+            current_date_players.clear();
+            last_date = player.date.clone();
+        }
+
+        // Only consider TIMS picks for predictions
+        if player.tims >= 1 && player.tims <= 3 {
+            current_date_players.push(i);
+        }
+    }
+
+    // Process the last date
+    let date_correct = process_date_predictions(&current_date_players, players, probabilities);
+    correct += date_correct;
+    total_predictions += 3;
+
+    (correct, total_predictions)
+}
+
+// Helper function to process predictions for a single date
+pub fn process_date_predictions(player_indices: &[usize], players: &[PlayerInfo], probabilities: &[f32]) -> i32 {
+    let mut correct = 0;
+    let mut selected_players = [None; 3]; // One for each TIMS group (1, 2, 3)
+
+    // Find the best player for each TIMS group
+    for &player_idx in player_indices.iter() {
+        let player = &players[player_idx];
+        let prob = probabilities[player_idx];
+        let group_idx = (player.tims - 1) as usize;
+
+        if group_idx < 3 {
+            match &selected_players[group_idx] {
+                None => selected_players[group_idx] = Some((player_idx, prob)),
+                Some((_, current_prob)) if prob > *current_prob => {
+                    selected_players[group_idx] = Some((player_idx, prob));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Count correct predictions and total predictions made
+    for selected in selected_players.iter() {
+        if let Some((player_idx, _)) = selected {
+            if players[*player_idx].scored > 0.0 {
+                correct += 1;
+            }
+        }
+    }
+
+    correct
+}

--- a/smartscore/scripts/find_weights.py
+++ b/smartscore/scripts/find_weights.py
@@ -1,53 +1,36 @@
-import ctypes
 import os
 import sys
 import time
-
-from smartscore_info_client.schemas.player_info import PlayerInfo, TestingPlayerInfoC
+from concurrent.futures import ThreadPoolExecutor
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import make_predictions_rust
 from shared import get_data
 
 from service import get_min_max  # noqa: E402
 
 
-class MinMaxC(ctypes.Structure):
-    _fields_ = [
-        ("min_gpg", ctypes.c_float),
-        ("max_gpg", ctypes.c_float),
-        ("min_hgpg", ctypes.c_float),
-        ("max_hgpg", ctypes.c_float),
-        ("min_five_gpg", ctypes.c_float),
-        ("max_five_gpg", ctypes.c_float),
-        ("min_tgpg", ctypes.c_float),
-        ("max_tgpg", ctypes.c_float),
-        ("min_otga", ctypes.c_float),
-        ("max_otga", ctypes.c_float),
-        ("min_hppg", ctypes.c_float),
-        ("max_hppg", ctypes.c_float),
-        ("min_otshga", ctypes.c_float),
-        ("max_otshga", ctypes.c_float),
-    ]
+def test_chunk(filtered_players, min_max_obj, weight_chunk):
+    return make_predictions_rust.test_weights(filtered_players, min_max_obj, weight_chunk)
 
 
-def create_min_max(min_max):
-    min_max_c = MinMaxC()
-    min_max_c.min_gpg = min_max.get("gpg", {}).get("min")
-    min_max_c.max_gpg = min_max.get("gpg", {}).get("max")
-    min_max_c.min_hgpg = min_max.get("hgpg", {}).get("min")
-    min_max_c.max_hgpg = min_max.get("hgpg", {}).get("max")
-    min_max_c.min_five_gpg = min_max.get("five_gpg", {}).get("min")
-    min_max_c.max_five_gpg = min_max.get("five_gpg", {}).get("max")
-    min_max_c.min_tgpg = min_max.get("tgpg", {}).get("min")
-    min_max_c.max_tgpg = min_max.get("tgpg", {}).get("max")
-    min_max_c.min_otga = min_max.get("otga", {}).get("min")
-    min_max_c.max_otga = min_max.get("otga", {}).get("max")
-    min_max_c.min_hppg = min_max.get("hppg", {}).get("min")
-    min_max_c.max_hppg = min_max.get("hppg", {}).get("max")
-    min_max_c.min_otshga = min_max.get("otshga", {}).get("min")
-    min_max_c.max_otshga = min_max.get("otshga", {}).get("max")
-
-    return min_max_c
+def create_min_max_dict(min_max):
+    return {
+        "min_gpg": min_max.get("gpg", {}).get("min"),
+        "max_gpg": min_max.get("gpg", {}).get("max"),
+        "min_hgpg": min_max.get("hgpg", {}).get("min"),
+        "max_hgpg": min_max.get("hgpg", {}).get("max"),
+        "min_five_gpg": min_max.get("five_gpg", {}).get("min"),
+        "max_five_gpg": min_max.get("five_gpg", {}).get("max"),
+        "min_tgpg": min_max.get("tgpg", {}).get("min"),
+        "max_tgpg": min_max.get("tgpg", {}).get("max"),
+        "min_otga": min_max.get("otga", {}).get("min"),
+        "max_otga": min_max.get("otga", {}).get("max"),
+        "min_hppg": min_max.get("hppg", {}).get("min"),
+        "max_hppg": min_max.get("hppg", {}).get("max"),
+        "min_otshga": min_max.get("otshga", {}).get("min"),
+        "max_otshga": min_max.get("otshga", {}).get("max"),
+    }
 
 
 def get_players():
@@ -59,67 +42,63 @@ def get_players():
             row["tims"] = 0.0
 
         all_players.append(
-            PlayerInfo(
-                name=row["name"],
-                date=row["date"],
+            make_predictions_rust.PlayerInfo(
                 gpg=row["gpg"],
                 hgpg=row["hgpg"],
                 five_gpg=row["five_gpg"],
-                hppg=row["hppg"],
-                scored=row.get("scored", None),
                 tgpg=row.get("tgpg", 0.0),
                 otga=row.get("otga", 0.0),
+                hppg=row["hppg"],
                 otshga=row.get("otshga", 0.0),
                 is_home=row.get("home", 0.0),
-                tims=row.get("tims", 0.0),
+                hppg_otshga=0.0,
+                scored=row.get("scored", 0.0),
+                tims=int(row.get("tims", 0.0)),
+                date=row["date"],
             )
         )
     return all_players
 
 
-def create_player_info_array(players):
-    # remove players who don't have scoring data or weren't a tims pick
-    players = [player for player in players if player.scored not in {" ", "null"} and player.tims in {1, 2, 3}]
+def call_rust_function(all_players):
+    # Filter players who have scoring data and were tims picks
+    filtered_players = [player for player in all_players if player.scored in {0.0, 1.0} and player.tims in {1, 2, 3}]
 
-    ExtendedTestingPlayerArrayC = TestingPlayerInfoC * len(players)
-    player_array = ExtendedTestingPlayerArrayC()
+    # Sort players by date to ensure proper grouping
+    filtered_players.sort(key=lambda p: p.date)
 
-    for i, player in enumerate(players):
-        if player.scored not in {" ", "null"}:
-            player_array[i].gpg = float(player.gpg)
-            player_array[i].hgpg = float(player.hgpg)
-            player_array[i].five_gpg = float(player.five_gpg)
-            player_array[i].tgpg = float(player.tgpg)
-            player_array[i].otga = float(player.otga)
-            player_array[i].is_home = float(player.is_home)
-            player_array[i].hppg = float(player.hppg)
-            player_array[i].otshga = float(player.otshga)
-            player_array[i].hppg_otshga = 0.0
+    # Create min_max object
+    min_max = create_min_max_dict(get_min_max())
+    min_max_obj = make_predictions_rust.MinMax(**min_max)
 
-            player_array[i].scored = float(player.scored)
-            player_array[i].tims = float(player.tims)
-            player_array[i].date = player.date.encode("utf-8")
+    # Generate all possible weight combinations using Rust implementation
+    print("Generating weight permutations...")
+    weight_combinations = make_predictions_rust.generate_weight_permutations(5)
 
-    return player_array
+    # Split weights and test in parallel
+    logical_cores = os.cpu_count() or 4
+    print(f"Testing {len(weight_combinations) // logical_cores} weight combinations using {logical_cores} CPU cores...")
+    num_processes = min(logical_cores, len(weight_combinations))
+    weight_chunks = [weight_combinations[i::num_processes] for i in range(num_processes)]
 
+    start_time_rust = time.time()
+    with ThreadPoolExecutor(max_workers=num_processes) as executor:
+        results = list(executor.map(lambda wc: test_chunk(filtered_players, min_max_obj, wc), weight_chunks))
+    rust_duration = time.time() - start_time_rust
 
-# call C function
-def call_c_function(all_players):
-    player_array = create_player_info_array(all_players)
-    size = len(player_array)
-    probabilities = (ctypes.c_float * size)()
-    print(f"Size: {size}")
+    # Find the best among results
+    best_result = max(results, key=lambda x: x[1])
+    best_weights, max_correct, total_predictions = best_result
 
-    min_max_c = create_min_max(get_min_max())
+    print(f"Rust function took {rust_duration:.2f} seconds")
+    print(f"Best weights: {best_weights}")
+    print(f"Max correct: {max_correct}")
+    print(f"Total predictions: {total_predictions}")
+    print(f"Accuracy: {max_correct / total_predictions:.1%}")
 
-    num_tims_dates = len(set(player.date for player in player_array))
-    players_lib = ctypes.CDLL("./smartscore/compiled_code.so")
-
-    start_time = time.time()
-    players_lib.test_weights(player_array, size, min_max_c, probabilities, num_tims_dates)
-    print(f"C function took {time.time() - start_time:.2f} seconds")
+    return best_weights, max_correct
 
 
 if __name__ == "__main__":
     all_players = get_players()
-    probabilities = call_c_function(all_players)
+    best_weights, max_correct = call_rust_function(all_players)

--- a/smartscore/scripts/find_weights_c.py
+++ b/smartscore/scripts/find_weights_c.py
@@ -1,0 +1,170 @@
+import ctypes
+import os
+import sys
+import time
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from shared import get_data
+
+from service import get_min_max  # noqa: E402
+
+# Load the compiled C library
+lib_path = os.path.join(os.path.dirname(__file__), "..", "compiled_code.so")
+c_lib = ctypes.CDLL(lib_path)
+
+
+# Define C structures matching the header.h
+class PlayerInfo(ctypes.Structure):
+    _fields_ = [
+        ("gpg", ctypes.c_float),
+        ("hgpg", ctypes.c_float),
+        ("five_gpg", ctypes.c_float),
+        ("tgpg", ctypes.c_float),
+        ("otga", ctypes.c_float),
+        ("hppg", ctypes.c_float),
+        ("otshga", ctypes.c_float),
+        ("is_home", ctypes.c_float),
+        ("hppg_otshga", ctypes.c_float),
+    ]
+
+
+class TestingPlayerInfo(ctypes.Structure):
+    _fields_ = [
+        ("gpg", ctypes.c_float),
+        ("hgpg", ctypes.c_float),
+        ("five_gpg", ctypes.c_float),
+        ("tgpg", ctypes.c_float),
+        ("otga", ctypes.c_float),
+        ("hppg", ctypes.c_float),
+        ("otshga", ctypes.c_float),
+        ("is_home", ctypes.c_float),
+        ("hppg_otshga", ctypes.c_float),
+        ("scored", ctypes.c_float),
+        ("tims", ctypes.c_float),
+        ("date", ctypes.c_char_p),
+    ]
+
+
+class MinMax(ctypes.Structure):
+    _fields_ = [
+        ("min_gpg", ctypes.c_float),
+        ("max_gpg", ctypes.c_float),
+        ("min_hgpg", ctypes.c_float),
+        ("max_hgpg", ctypes.c_float),
+        ("min_five_gpg", ctypes.c_float),
+        ("max_five_gpg", ctypes.c_float),
+        ("min_tgpg", ctypes.c_float),
+        ("max_tgpg", ctypes.c_float),
+        ("min_otga", ctypes.c_float),
+        ("max_otga", ctypes.c_float),
+        ("min_hppg", ctypes.c_float),
+        ("max_hppg", ctypes.c_float),
+        ("min_otshga", ctypes.c_float),
+        ("max_otshga", ctypes.c_float),
+    ]
+
+
+class Weights(ctypes.Structure):
+    _fields_ = [
+        ("gpg", ctypes.c_float),
+        ("hgpg", ctypes.c_float),
+        ("five_gpg", ctypes.c_float),
+        ("tgpg", ctypes.c_float),
+        ("otga", ctypes.c_float),
+        ("is_home", ctypes.c_float),
+        ("hppg_otshga", ctypes.c_float),
+    ]
+
+
+# Define function signatures
+c_lib.test_weights.argtypes = [
+    ctypes.POINTER(TestingPlayerInfo),
+    ctypes.c_int,
+    MinMax,
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
+]
+c_lib.test_weights.restype = None
+
+
+def create_min_max_dict(min_max):
+    return {
+        "min_gpg": min_max.get("gpg", {}).get("min"),
+        "max_gpg": min_max.get("gpg", {}).get("max"),
+        "min_hgpg": min_max.get("hgpg", {}).get("min"),
+        "max_hgpg": min_max.get("hgpg", {}).get("max"),
+        "min_five_gpg": min_max.get("five_gpg", {}).get("min"),
+        "max_five_gpg": min_max.get("five_gpg", {}).get("max"),
+        "min_tgpg": min_max.get("tgpg", {}).get("min"),
+        "max_tgpg": min_max.get("tgpg", {}).get("max"),
+        "min_otga": min_max.get("otga", {}).get("min"),
+        "max_otga": min_max.get("otga", {}).get("max"),
+        "min_hppg": min_max.get("hppg", {}).get("min"),
+        "max_hppg": min_max.get("hppg", {}).get("max"),
+        "min_otshga": min_max.get("otshga", {}).get("min"),
+        "max_otshga": min_max.get("otshga", {}).get("max"),
+    }
+
+
+def get_players():
+    data, labels = get_data()
+
+    all_players = []
+    for index, row in data.iterrows():
+        if row["tims"] not in {0, 1, 2, 3}:
+            row["tims"] = 0.0
+
+        all_players.append(
+            TestingPlayerInfo(
+                gpg=row["gpg"],
+                hgpg=row["hgpg"],
+                five_gpg=row["five_gpg"],
+                tgpg=row.get("tgpg", 0.0),
+                otga=row.get("otga", 0.0),
+                hppg=row["hppg"],
+                otshga=row.get("otshga", 0.0),
+                is_home=row.get("home", 0.0),
+                hppg_otshga=0.0,  # Will be calculated in C
+                scored=row.get("scored", 0.0),
+                tims=row.get("tims", 0.0),
+                date=row["date"].encode("utf-8"),  # Convert to bytes
+            )
+        )
+    return all_players
+
+
+def call_c_function(all_players):
+    # Filter players who have scoring data and were tims picks
+    filtered_players = [player for player in all_players if player.scored in {0.0, 1.0} and player.tims in {1, 2, 3}]
+
+    # Sort players by date to ensure proper grouping
+    filtered_players.sort(key=lambda p: p.date.decode("utf-8"))
+
+    # Create min_max object
+    min_max_dict = create_min_max_dict(get_min_max())
+    min_max = MinMax(**min_max_dict)
+
+    # Count unique dates with TIMS picks
+    unique_dates = set()
+    for player in filtered_players:
+        unique_dates.add(player.date.decode("utf-8"))
+    num_tims_dates = len(unique_dates)
+
+    # Prepare arrays for C function
+    num_players = len(filtered_players)
+    players_array = (TestingPlayerInfo * num_players)(*filtered_players)
+    probabilities = (ctypes.c_float * num_players)()
+
+    print("Testing weights using C implementation")
+
+    # Call C function
+    start_time_c = time.time()
+    c_lib.test_weights(players_array, num_players, min_max, probabilities, num_tims_dates)
+    c_duration = time.time() - start_time_c
+
+    print(f"C function took {c_duration:.2f} seconds")
+
+
+if __name__ == "__main__":
+    all_players = get_players()
+    call_c_function(all_players)


### PR DESCRIPTION
- Added new data types for PlayerInfo, MinMax, and Weights in `data_types.rs`.
- Implemented normalization and probability calculation functions in `predictions.rs`.
- Created weight generation and testing modules in `weight_generation.rs` and `weight_testing.rs`.
- Updated `lib.rs` to re-export new modules and functions for Python integration.
- Modified `Cargo.toml` and `Cargo.lock` to include new dependencies (crossbeam and rayon).
- Refactored Python script `find_weights.py` to utilize Rust functions for weight testing.
- Introduced a new C-based weight testing script `find_weights_c.py` for performance comparison.